### PR TITLE
Utilize previous `theta` estimate in optimization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * Wrap the dispersion variable `phi` in `exp()` to ensure that it is a possible value.
 
+## Improvements
+
+* Now the starting guess for the models parameters, `theta`, is based on the previous round of optimization. This increases the performance and robustness of the paramter estimation.
+
 # aeddo 0.1.1
 
 ## Patch

--- a/R/aeddo.R
+++ b/R/aeddo.R
@@ -128,7 +128,7 @@ aeddo <- function(
   }
 
   # Set starting guess for theta 
-  theta <- init_theta
+  theta <- init_theta # TODO: #17 Implement a method to infer the initial `theta`, `lower`, and `upper`
 
   # Loop over the observations to perform windowed estimation
   for (i in 1:(n_observation - k)) {

--- a/R/aeddo.R
+++ b/R/aeddo.R
@@ -127,6 +127,9 @@ aeddo <- function(
     )
   }
 
+  # Set starting guess for theta 
+  theta <- init_theta
+
   # Loop over the observations to perform windowed estimation
   for (i in 1:(n_observation - k)) {
     # Extract data point for this estimation window
@@ -160,7 +163,7 @@ aeddo <- function(
 
     # Gather all arguments in a list for`do.call()`
     optimiser_arguments <- list(
-      par = init_theta,
+      par = theta,
       data = window_data,
       formula = formula,
       fn = nll_poisson_gamma,
@@ -216,6 +219,9 @@ aeddo <- function(
       past_outbreaks <- past_outbreaks %>%
         dplyr::bind_rows(reference_data)
     }
+
+    # Set starting guess for theta given last round of optimization
+    theta <- optimized_param$par * 0.7
   }
 
   return(results)


### PR DESCRIPTION
Utilize the previous round of optimized parameters, `theta`, as a starting guess for the next round of optimization. Fixes #15